### PR TITLE
Enable CPU intrinsics

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@ Loading the index from index.bin...
 At the directory `bench`, you can measure lookup times using *N*-gram data in `test_data` with the following command:
 
 ```
-$ cargo bench
+$ RUSTFLAGS="-C target-cpu=native" cargo bench
 count_lookup/tongrams/EliasFanoTrieCountLm                                                                            
-                        time:   [3.9481 ms 3.9540 ms 3.9605 ms]
+                        time:   [3.1818 ms 3.1867 ms 3.1936 ms]
 ```
 
 The reported time is the total elapsed time for looking up 5K random grams.
 
-On my laptop PC (i7, 16GB RAM), the average lookup time was 0.79 micro sec per query, although the original tongram performed lookup in 0.44 micro sec per query.
+On my laptop PC (i7, 16GB RAM), the average lookup time was 0.64 micro sec per query, although the original tongram performed lookup in 0.44 micro sec per query.
 
 ## Todo
 

--- a/tongrams/Cargo.toml
+++ b/tongrams/Cargo.toml
@@ -11,5 +11,5 @@ bincode = "1.3.3"
 byteorder = "1.4.3"
 flate2 = "1.0"
 serde_json = "1.0"
-sucds = "0.1.8"
+sucds = { version = "0.1.8", features = ["intrinsics"] }
 yada = "0.5.0"


### PR DESCRIPTION
This PR enabled CPU intrinsics.

```
$ RUSTFLAGS="-C target-cpu=native" cargo bench
count_lookup/tongrams/EliasFanoTrieCountLm                                                                            
                        time:   [3.1818 ms 3.1867 ms 3.1936 ms]
                        change: [-18.659% -18.380% -18.117%] (p = 0.00 < 0.05)
                        Performance has improved.
```